### PR TITLE
Follow-Up Approve & Send Fixes

### DIFF
--- a/app/api/followups/route.ts
+++ b/app/api/followups/route.ts
@@ -10,7 +10,7 @@ import {
 import type { GetFollowupsResponse } from "@/lib/api-types";
 
 const SELECT =
-  "id,status,owner_message,recommended_action,draft_response,differentials,conversation,tool_call_count,sent_at,created_at,visits(visit_date,raw_notes,patients(name,owner_name))";
+  "id,status,owner_message,recommended_action,draft_response,differentials,conversation,tool_call_count,sent_at,created_at,telegram_chat_id,visits(visit_date,raw_notes,patients(id,name,owner_name))";
 
 export async function GET() {
   try {

--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -18,7 +18,7 @@
 import { ApiError } from "@/lib/api-types";
 import { errorResponse, json } from "@/lib/api-response";
 import { ENV, hasTelegram, isProduction } from "@/lib/env";
-import { handleOwnerMessage } from "@/lib/telegram-handler";
+import { handleOwnerMessage, ownerAutoReply } from "@/lib/telegram-handler";
 import { sendTelegramMessage } from "@/lib/telegram";
 
 type TgPhotoSize = {
@@ -85,11 +85,15 @@ export async function POST(req: Request) {
       return json({ ok: true, skipped: "no text or photo" });
     }
 
-    const { reply, decision, followupId, photoUrls } = await handleOwnerMessage(
-      chatId,
-      { text, photoFileIds: photoFileIds.length > 0 ? photoFileIds : undefined },
-    );
-    await sendTelegramMessage(chatId, reply);
+    const result = await handleOwnerMessage(chatId, {
+      text,
+      photoFileIds: photoFileIds.length > 0 ? photoFileIds : undefined,
+    });
+    const { decision, followupId, photoUrls } = result;
+    // Terminal decisions (escalate/monitor/clear) wait for doctor approval —
+    // the AI's reply draft is persisted to followups.draft_response and the
+    // owner gets a brief holding message instead.
+    await sendTelegramMessage(chatId, ownerAutoReply(result));
 
     // Don't log photo URLs — they're public bucket links that bypass auth and
     // can leak into logs/SIEM. Just record presence and count.

--- a/components/app-shell/escalation-modal.tsx
+++ b/components/app-shell/escalation-modal.tsx
@@ -313,8 +313,16 @@ function DifferentialBar({
 }
 
 export default function EscalationModal() {
-  const { escalation, closeEscalation, approveEscalation } = useStore();
+  const {
+    escalation,
+    closeEscalation,
+    approveEscalation,
+    approving,
+    approveError,
+  } = useStore();
   const [mounted, setMounted] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editedDraft, setEditedDraft] = useState("");
 
   useEffect(() => {
     if (!escalation) return;
@@ -329,6 +337,13 @@ export default function EscalationModal() {
       setMounted(false);
     };
   }, [escalation, closeEscalation]);
+
+  // Reset editor whenever a different escalation opens (or its draft changes
+  // upstream — e.g. owner sent another message and triage re-ran).
+  useEffect(() => {
+    setEditing(false);
+    setEditedDraft(escalation?.draft ?? "");
+  }, [escalation?.id, escalation?.draft]);
 
   if (!escalation) return null;
   const f = escalation;
@@ -530,24 +545,49 @@ export default function EscalationModal() {
               marginBottom: 8,
             }}
           >
-            Draft response · ready to send
+            Draft response · {editing ? "editing" : "ready to send"}
           </div>
-          <div
-            style={{
-              padding: "14px 16px",
-              borderRadius: RADIUS.md,
-              background: "#FBFAF7",
-              border: BORDER_HAIRLINE,
-              fontFamily: FONT_MONO,
-              fontSize: 13,
-              lineHeight: 1.6,
-              color: C.ink,
-              marginBottom: 16,
-              whiteSpace: "pre-wrap",
-            }}
-          >
-            {f.draft}
-          </div>
+          {editing ? (
+            <textarea
+              value={editedDraft}
+              onChange={(e) => setEditedDraft(e.target.value)}
+              autoFocus
+              spellCheck
+              style={{
+                width: "100%",
+                minHeight: 140,
+                padding: "14px 16px",
+                borderRadius: RADIUS.md,
+                background: "#FFFFFF",
+                border: `1px solid ${C.brand}`,
+                fontFamily: FONT_MONO,
+                fontSize: 13,
+                lineHeight: 1.6,
+                color: C.ink,
+                marginBottom: 16,
+                resize: "vertical",
+                outline: "none",
+                boxSizing: "border-box",
+              }}
+            />
+          ) : (
+            <div
+              style={{
+                padding: "14px 16px",
+                borderRadius: RADIUS.md,
+                background: "#FBFAF7",
+                border: BORDER_HAIRLINE,
+                fontFamily: FONT_MONO,
+                fontSize: 13,
+                lineHeight: 1.6,
+                color: C.ink,
+                marginBottom: 16,
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {editedDraft || f.draft}
+            </div>
+          )}
         </div>
 
         {/* Action bar — PRD §F3: [Approve & Send] [Edit] [Call] */}
@@ -561,19 +601,36 @@ export default function EscalationModal() {
             background: "#FBFAF7",
           }}
         >
-          <Button size="md" onClick={approveEscalation} icon={Icon.check(15)}>
-            Approve &amp; Send
+          <Button
+            size="md"
+            onClick={() => {
+              void approveEscalation(editedDraft);
+            }}
+            disabled={approving || editing}
+            icon={Icon.check(15)}
+          >
+            {approving ? "Sending…" : "Approve & Send"}
           </Button>
-          <Button variant="soft" size="md" icon={Icon.edit(14)}>
-            Edit
+          <Button
+            variant="soft"
+            size="md"
+            onClick={() => setEditing((v) => !v)}
+            disabled={approving}
+            icon={editing ? Icon.check(14) : Icon.edit(14)}
+          >
+            {editing ? "Save" : "Edit"}
           </Button>
           <Button variant="soft" size="md" icon={Icon.phone(14)}>
             Call Owner
           </Button>
           <div style={{ flex: 1 }} />
-          <div style={{ fontSize: 11.5, color: C.muted }}>
-            Logs feedback · auto-sends via Telegram
-          </div>
+          {approveError ? (
+            <div style={{ fontSize: 11.5, color: "#B23A3A" }}>{approveError}</div>
+          ) : (
+            <div style={{ fontSize: 11.5, color: C.muted }}>
+              Sends draft via Telegram on approval
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/components/app-shell/store.tsx
+++ b/components/app-shell/store.tsx
@@ -27,9 +27,11 @@ interface StoreCtx {
   // UI state
   toast: string | null;
   escalation: FollowUp | null;
+  approving: boolean;
+  approveError: string | null;
   openEscalation: (f: FollowUp) => void;
   closeEscalation: () => void;
-  approveEscalation: () => void;
+  approveEscalation: (overrideDraft?: string) => Promise<void>;
   setToast: (msg: string | null) => void;
   flashToast: (msg: string) => void;
   expandedPatient: string | null;
@@ -55,6 +57,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
   const [toast, setToast] = useState<string | null>(null);
   const [escalation, setEscalation] = useState<FollowUp | null>(null);
+  const [approving, setApproving] = useState(false);
+  const [approveError, setApproveError] = useState<string | null>(null);
   const [expandedPatient, setExpandedPatient] = useState<string | null>(null);
 
   // `silent` skips the loading skeleton flash — used for Realtime-triggered
@@ -142,14 +146,43 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     setTimeout(() => setToast(null), 3400);
   }, []);
 
-  const openEscalation = useCallback((f: FollowUp) => setEscalation(f), []);
-  const closeEscalation = useCallback(() => setEscalation(null), []);
-  const approveEscalation = useCallback(() => {
-    setEscalation((cur) => {
-      if (!cur) return null;
-      setFollowups((fs) => fs.filter((x) => x.id !== cur.id));
-      setResolvedCount((c) => c + 1);
-      // fire-and-forget — mock route just logs
+  const openEscalation = useCallback((f: FollowUp) => {
+    setApproveError(null);
+    setEscalation(f);
+  }, []);
+  const closeEscalation = useCallback(() => {
+    setApproveError(null);
+    setEscalation(null);
+  }, []);
+  const approveEscalation = useCallback(async (overrideDraft?: string) => {
+    const cur = escalation;
+    if (!cur || approving) return;
+
+    const body = (overrideDraft ?? cur.draft ?? "").trim();
+    if (!body) {
+      setApproveError("No draft to send.");
+      return;
+    }
+    if (!cur.chatId) {
+      setApproveError(
+        "No Telegram chat linked to this follow-up — cannot send.",
+      );
+      return;
+    }
+    if (!cur.patientId) {
+      setApproveError("No patient linked to this follow-up — cannot send.");
+      return;
+    }
+
+    setApproving(true);
+    setApproveError(null);
+    try {
+      await api.telegramSend({
+        chatId: cur.chatId,
+        body,
+        patientId: cur.patientId,
+      });
+      // Log the doctor's approval after a successful delivery.
       void api
         .correction({
           feature: "triage",
@@ -158,10 +191,16 @@ export function StoreProvider({ children }: { children: ReactNode }) {
           approved: true,
         })
         .catch(() => {});
+      setFollowups((fs) => fs.filter((x) => x.id !== cur.id));
+      setResolvedCount((c) => c + 1);
       flashToast(`Sent to ${cur.owner} · ${cur.patient} closed`);
-      return null;
-    });
-  }, [flashToast]);
+      setEscalation(null);
+    } catch (err) {
+      setApproveError(err instanceof Error ? err.message : "send failed");
+    } finally {
+      setApproving(false);
+    }
+  }, [escalation, approving, flashToast]);
 
   return (
     <Ctx.Provider
@@ -175,6 +214,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
         refresh,
         toast,
         escalation,
+        approving,
+        approveError,
         openEscalation,
         closeEscalation,
         approveEscalation,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -16,6 +16,8 @@ import type {
   GetPatientsResponse,
   CreatePatientRequest,
   CreatePatientResponse,
+  TelegramSendRequest,
+  TelegramSendResponse,
   TriageRequest,
   TriageResponse,
 } from "./api-types";
@@ -56,6 +58,11 @@ export const api = {
     postJSON<TriageRequest, TriageResponse>("/api/triage", req),
   correction: (req: CorrectionRequest) =>
     postJSON<CorrectionRequest, CorrectionResponse>("/api/corrections", req),
+  telegramSend: (req: TelegramSendRequest) =>
+    postJSON<TelegramSendRequest, TelegramSendResponse>(
+      "/api/consult/telegram-send",
+      req,
+    ),
 
   /** Multipart upload of one or more images to a Supabase Storage bucket. */
   uploadPhotos: async (

--- a/lib/supabase-mappers.ts
+++ b/lib/supabase-mappers.ts
@@ -80,10 +80,11 @@ export type FollowupRow = {
   tool_call_count: number | null;
   sent_at: string | null;
   created_at: string;
+  telegram_chat_id: string | null;
   visits: {
     visit_date: string;
     raw_notes: string | null;
-    patients: { name: string; owner_name: string | null } | null;
+    patients: { id: string; name: string; owner_name: string | null } | null;
   } | null;
 };
 
@@ -167,5 +168,7 @@ export function rowToFollowUp(r: FollowupRow): FollowUp {
     tsLabel: undefined,
     conversation: parseConversation(r.conversation),
     toolCallCount: r.tool_call_count ?? 0,
+    chatId: r.telegram_chat_id ?? undefined,
+    patientId: patient?.id ?? undefined,
   };
 }

--- a/lib/telegram-handler.ts
+++ b/lib/telegram-handler.ts
@@ -46,6 +46,31 @@ export interface HandleOwnerMessageResult {
   photoUrls?: string[];
 }
 
+/**
+ * Holding message sent to the owner when the AI reaches a terminal triage
+ * decision (escalate / monitor / clear). The actual reply draft is held
+ * for doctor review and only delivered when the doctor clicks
+ * "Approve & Send" in the UI.
+ */
+const HOLDING_REPLY =
+  "Thanks — we've got your update. Your vet will review and reply shortly.";
+
+/** Terminal decisions never auto-send; they wait for doctor approval. */
+export function isTerminalDecision(
+  d: HandleOwnerMessageResult["decision"],
+): boolean {
+  return d === "escalate" || d === "monitor" || d === "clear";
+}
+
+/**
+ * What to actually send back to the owner immediately. Tool-call prompts
+ * (info-gathering) and unlinked-chat help auto-send; terminal medical
+ * decisions return the holding message and wait for doctor approval.
+ */
+export function ownerAutoReply(result: HandleOwnerMessageResult): string {
+  return isTerminalDecision(result.decision) ? HOLDING_REPLY : result.reply;
+}
+
 export interface OwnerMessageInput {
   /** Caption text (may be empty when only a photo was sent). */
   text: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -79,6 +79,10 @@ export interface FollowUp {
   tsLabel?: string;
   conversation?: ConversationTurn[];
   toolCallCount?: number;
+  /** Telegram chat id of the owner — required for the doctor-approved send. */
+  chatId?: string;
+  /** Patient row id — required by /api/consult/telegram-send for owner_telegram backwrite. */
+  patientId?: string;
 }
 
 export interface MetricCardData {

--- a/scripts/start-bot.ts
+++ b/scripts/start-bot.ts
@@ -17,7 +17,9 @@ loadEnvConfig(process.cwd());
 
 (async () => {
   const { getBot } = await import("../lib/telegram");
-  const { handleOwnerMessage } = await import("../lib/telegram-handler");
+  const { handleOwnerMessage, ownerAutoReply } = await import(
+    "../lib/telegram-handler"
+  );
   const { ENV } = await import("../lib/env");
 
   const bot = getBot();
@@ -39,14 +41,14 @@ loadEnvConfig(process.cwd());
     if (text.startsWith("/")) return; // commands handled above
     console.log(`[bot] <- ${chatId}: ${text}`);
     try {
-      const { reply, decision, followupId, confidence } =
-        await handleOwnerMessage(chatId, { text });
+      const result = await handleOwnerMessage(chatId, { text });
+      const { decision, followupId, confidence } = result;
       console.log(
         `[bot] -> decision=${decision} followup=${followupId ?? "(unlinked)"} conf=${
           confidence ?? "-"
         }`,
       );
-      await ctx.reply(reply);
+      await ctx.reply(ownerAutoReply(result));
     } catch (err) {
       console.error("[bot] error handling message", err);
       await ctx.reply(
@@ -66,17 +68,17 @@ loadEnvConfig(process.cwd());
       `[bot] <- ${chatId}: [photo${caption ? ` + caption: "${caption}"` : ""}]`,
     );
     try {
-      const { reply, decision, followupId, confidence, photoUrls } =
-        await handleOwnerMessage(chatId, {
-          text: caption,
-          photoFileIds: [largest.file_id],
-        });
+      const result = await handleOwnerMessage(chatId, {
+        text: caption,
+        photoFileIds: [largest.file_id],
+      });
+      const { decision, followupId, confidence, photoUrls } = result;
       console.log(
         `[bot] -> decision=${decision} followup=${followupId ?? "(unlinked)"} conf=${
           confidence ?? "-"
         } photo=${photoUrls?.[0] ?? "(none)"}`,
       );
-      await ctx.reply(reply);
+      await ctx.reply(ownerAutoReply(result));
     } catch (err) {
       console.error("[bot] error handling photo", err);
       await ctx.reply(


### PR DESCRIPTION
Hey Shawn please approve this fix after checking. Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now edit escalation response drafts before approval in the escalation modal.
  * Enhanced error handling and status feedback during escalation approval.

* **Improvements**
  * Telegram message sending now includes auto-generated holding replies for terminal triage decisions.
  * Follow-up data now tracks additional patient and chat identifiers for improved message routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->