### PR TITLE
fix(consult): bump aftercare-item cap from 200 to 500 chars

### DIFF
--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -205,7 +205,7 @@ export interface TelegramSendResponse {
 // below that to leave room for the aftercare suffix the route appends.
 const MAX_TG_BODY_LEN = 3_500;
 const MAX_TG_AFTERCARE_ITEMS = 12;
-const MAX_TG_AFTERCARE_ITEM_LEN = 200;
+const MAX_TG_AFTERCARE_ITEM_LEN = 500;
 export function parseTelegramSendRequest(raw: unknown): TelegramSendRequest {
   const r = raw as Partial<TelegramSendRequest>;
   if (!r || typeof r !== "object") throw new ApiError(400, "body must be object");


### PR DESCRIPTION
Long-form aftercare bullets generated by the consult model were tripping the 200-char per-item validator in
parseTelegramSendRequest, returning 413 from
/api/consult/telegram-send. Telegram itself caps messages at 4096, so 500 per bullet is still safely below the wire limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Increased the maximum character limit for Telegram aftercare items from 200 to 500 characters, allowing for longer and more detailed information to be included in messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->