### PR TITLE
chore: add FINAL pitch deck and allow manual AI eval runs

### DIFF
--- a/.github/workflows/ai-eval.yml
+++ b/.github/workflows/ai-eval.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "agent/**"   # only run when agent code changes — saves API costs
+  workflow_dispatch:   # allow manual runs from the Actions tab
 
 jobs:
   eval:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All five required submission artifacts are checked into this repository for easy
 | 2 | 🧪 **Refined QA Testing Document** | [`Refined QATD.pdf`](./Refined%20QATD.pdf) — source: [`refined_qa.md`](./refined_qa.md) | Updated test strategy, expanded test matrix, coverage, defect tracking and regression plan for the final round. |
 | 3 | 🚀 **Deployment Plan** | [`Deployment Plan.pdf`](./Deployment%20Plan.pdf) — source: [`cicd.md`](./cicd.md) | Architecture, environments, CI/CD (Vercel + GitHub Actions AI-eval + Supabase migrations + clinic-brain-sync cron), secret management, step-by-step deploy, monitoring, rollback, risks. |
 | 4 | 📈 **Business Proposal** | [`UMHackathon2026 Business Proposal (DAHOMIES).pdf`](./UMHackathon2026%20Business%20Proposal%20%28DAHOMIES%29.pdf) — source: [`business_proposal.md`](./business_proposal.md) | Market sizing, pricing tiers, go-to-market motion, unit economics, and financial model for the developed product. |
-| 5 | 🎤 **Final Round Pitch Deck** | [`Consilium Pitch Deck.pdf`](./Consilium%20Pitch%20Deck.pdf) | Final-round presentation slides covering problem, solution, decision layer, demo highlights, traction, and ask. |
+| 5 | 🎤 **Final Round Pitch Deck** | [`Consilium Pitch Deck FINAL.pdf`](./Consilium%20Pitch%20Deck%20FINAL.pdf) | Final-round presentation slides covering problem, solution, decision layer, demo highlights, traction, and ask. |
 
 📁 **Full submission Drive folder:** <https://drive.google.com/drive/u/0/folders/160O04WT0iuOfyCdfYf1EiLhesZAOUw5k>
 


### PR DESCRIPTION
- Adds Consilium Pitch Deck FINAL.pdf and points the README final-round deliverables table at the new file (replaces the older deck link).
- Adds workflow_dispatch to .github/workflows/ai-eval.yml so the triage eval can be triggered manually from the Actions tab without touching agent/ to retrigger.